### PR TITLE
publish msg.payload

### DIFF
--- a/lib/pub/pub.js
+++ b/lib/pub/pub.js
@@ -11,7 +11,7 @@ module.exports = function (RED) {
             format_values(msg);
             format_values(config);
             let topic = config.topic||msg.topic;
-            let message = config.message|| msg.message;
+            let message = config.message|| msg.message || msg.payload;
             if(typeof message == "object")
                 message = JSON.stringify(message);
                 // publish the message on to the conceptual queue

--- a/lib/sub/sub.js
+++ b/lib/sub/sub.js
@@ -3,7 +3,7 @@ module.exports = function (RED) {
     function sub(config) {
         RED.nodes.createNode(this, config);
         var node = this;
-        let topic = config.topic || msg.topic;
+        let topic = config.topic;
         PubSub.subscribe(topic, (message, data) => {
             let msg = {
                 topic:message,


### PR DESCRIPTION
Hi, 

I made a change to allow the pub node to just publish the value of msg.payload if its the only thing set, it will overide that with config.message or msg.message if those are set so shouldn't be a breaking change but it makes it easier to use these nodes with the output of existing nodes that as a convention send msg.payload.
I also removed the msg.topic option from the sub node as it would be impossible to set that, there's no msg object in existence at that point.